### PR TITLE
Fix hiding cast bar and party frames

### DIFF
--- a/ShadowedUF_Options/config.lua
+++ b/ShadowedUF_Options/config.lua
@@ -4831,7 +4831,10 @@ local function loadUnitOptions()
 
 	options.args.profile = LibStub("AceDBOptions-3.0"):GetOptionsTable(ShadowUF.db, true)
 	local LibDualSpec = LibStub("LibDualSpec-1.0", true)
-	if LibDualSpec then LibDualSpec:EnhanceOptions(options.args.profile, ShadowUF.db) end
+	if LibDualSpec then 
+		LibDualSpec:EnhanceDatabase(ShadowUF.db, "ShadowUF")
+		LibDualSpec:EnhanceOptions(options.args.profile, ShadowUF.db) 
+	end
 
 	options.args.enableUnits = {
 		type = "group",

--- a/ShadowedUnitFrames/ShadowedUnitFrames.lua
+++ b/ShadowedUnitFrames/ShadowedUnitFrames.lua
@@ -1004,13 +1004,25 @@ end
 local active_hiddens = {}
 function ShadowUF:HideBlizzardFrames()
 	if( self.db.profile.hidden.cast and not active_hiddens.cast ) then
-		hideBlizzardFrames(true, CastingBarFrame, PetCastingBarFrame)
+		hideBlizzardFrames(true, PlayerCastingBarFrame, PetCastingBarFrame)
 	end
 
 	if( self.db.profile.hidden.party and not active_hiddens.party ) then
-		for i=1, MAX_PARTY_MEMBERS do
-			local name = "PartyMemberFrame" .. i
-			hideBlizzardFrames(false, _G[name], _G[name .. "HealthBar"], _G[name .. "ManaBar"])
+		if( PartyFrame ) then
+			hideBlizzardFrames(false, PartyFrame)
+			for memberFrame in PartyFrame.PartyMemberFramePool:EnumerateActive() do
+				if memberFrame.HealthBarContainer and memberFrame.HealthBarContainer.HealthBar then
+					hideBlizzardFrames(false, memberFrame, memberFrame.HealthBarContainer.HealthBar, memberFrame.ManaBar)
+				else
+					hideBlizzardFrames(false, memberFrame, memberFrame.HealthBar, memberFrame.ManaBar)
+				end
+			end
+			PartyFrame.PartyMemberFramePool:ReleaseAll()
+		else
+			for i=1, MAX_PARTY_MEMBERS do
+				local name = "PartyMemberFrame" .. i
+				hideBlizzardFrames(false, _G[name], _G[name .. "HealthBar"], _G[name .. "ManaBar"])
+			end
 		end
 
 		-- This stops the compact party frame from being shown

--- a/ShadowedUnitFrames/modules/auras.lua
+++ b/ShadowedUnitFrames/modules/auras.lua
@@ -6,6 +6,22 @@ local GetAuraDataByIndex = C_UnitAuras.GetAuraDataByIndex
 
 ShadowUF:RegisterModule(Auras, "auras", ShadowUF.L["Auras"])
 
+local fallbackDebuffTypeColor = {
+	none = {r = 0.80, g = 0, b = 0},
+	Magic = {r = 0.20, g = 0.60, b = 1.00},
+	Curse = {r = 0.60, g = 0, b = 1.00},
+	Disease = {r = 0.60, g = 0.40, b = 0},
+	Poison = {r = 0, g = 0.60, b = 0},
+}
+
+local function getDebuffTypeColor(auraType)
+	if( DebuffTypeColor ) then
+		return (auraType and DebuffTypeColor[auraType]) or DebuffTypeColor.none or fallbackDebuffTypeColor.none
+	end
+
+	return (auraType and fallbackDebuffTypeColor[auraType]) or fallbackDebuffTypeColor.none
+end
+
 function Auras:OnEnable(frame)
 	frame.auras = frame.auras or {}
 
@@ -545,7 +561,7 @@ local function renderAura(parent, frame, type, config, displayConfig, index, fil
 	if( isRemovable and not isFriendly and not ShadowUF.db.profile.auras.disableColor ) then
 		button.border:SetVertexColor(ShadowUF.db.profile.auraColors.removable.r, ShadowUF.db.profile.auraColors.removable.g, ShadowUF.db.profile.auraColors.removable.b)
 	elseif( ( not isFriendly or type == "debuffs" ) and not ShadowUF.db.profile.auras.disableColor ) then
-		local color = auraType and DebuffTypeColor[auraType] or DebuffTypeColor.none
+		local color = getDebuffTypeColor(auraType)
 		button.border:SetVertexColor(color.r, color.g, color.b)
 	else
 		button.border:SetVertexColor(0.60, 0.60, 0.60)


### PR DESCRIPTION
- Updated references to Blizzard's cast bar and party frames
- Apply fix for issue with aura border colors
- Added LibDualSpec's EnhanceDatabase function to options table call

Unsure if the config.lua change is necessary but it allowed me to open the options when trying to figure out what was broken and disable hiding the cast bar temporarily. 

FIXES #34 